### PR TITLE
Add initial specifications for oct CLI commands

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,28 @@
+# OCT Specification Index
+
+This folder holds specification documents for the Open Clinical Terminology (OCT) project.
+It provides:
+
+- A top-level specification covering coding style expectations and contribution patterns for OCT tooling.
+- Command-level specifications for the `oct` CLI, with one file per command.
+
+The documents are intended as living guidance for contributors and reviewers. They should be updated alongside code changes to keep the specification authoritative.
+
+## Coding Style and Development Standards
+
+- **Language & Tooling**: Python 3.10+ for CLI work, using [`click`](https://click.palletsprojects.com/) for command definitions and option parsing.
+- **Imports**: Group standard library, third-party, and local imports separately; avoid wildcard imports; never wrap imports in `try/except`.
+- **Typing**: Prefer explicit type hints for function arguments and return values. Use `Path` for filesystem paths.
+- **Error Handling**: Fail fast with clear, user-focused error messages; avoid silent failures. Capture predictable exceptions and surface actionable guidance.
+- **I/O & Filesystem**: Treat `tools/` as the CLI home, with `terms/` as the default data root. Keep path handling cross-platform by relying on `pathlib`.
+- **Logging & UX**: Use `click.echo` for user-facing output. Keep messages concise, with details only when helpful for troubleshooting.
+- **Testing & Validation**: Prefer small, deterministic functions. New behavior should be exercised by unit tests or smoke commands when feasible.
+- **Documentation**: Every command should have a dedicated spec file describing purpose, inputs, outputs, and side effects. Keep examples in sync with the CLI help text.
+- **Security & Integrity**: Use `secrets` for any identifier generation. Avoid writing files without explicit user intent. Check for existing artifacts before creating new ones.
+
+## File Layout
+
+- `spec/README.md` — This document and style expectations.
+- `spec/commands/<command>.md` — One file per CLI command.
+
+When adding new commands, create a matching spec file in `spec/commands/` and link it from relevant documentation.

--- a/spec/commands/new.md
+++ b/spec/commands/new.md
@@ -1,0 +1,34 @@
+# Command: `oct new`
+
+Create a new concept file with a unique Crockford Base32 identifier.
+
+## Purpose
+- Provide a fast, repeatable way to create empty `.oct` term files.
+- Ensure identifiers are globally unique within the terminology dataset.
+
+## Behavior
+- Default target directory is `terms/<language>/` relative to the repository root.
+- Uses a lowercase Crockford Base32 alphabet (excluding `i`, `l`, `o`, `u`) to generate a 6-character ID.
+- Retries up to 1000 times to avoid collisions; aborts with an error if uniqueness cannot be achieved.
+- Logs each creation event to `terms/terms` with an ISO 8601 timestamp and the generated identifier.
+- Creates an empty file named `<id>.oct` and prints the path and identifier.
+
+## Arguments & Options
+- `--directory`, `-d`: Override the target directory for the new file. Defaults to `terms/<language>/`.
+- `--language`, `-l`: Language code used to select the default directory. Defaults to `en-GB`.
+
+## Usage Examples
+```bash
+./oct new
+./oct new --language en-US
+./oct new --directory /custom/path
+```
+
+## Validation & Error Handling
+- If the target directory does not exist, it is created (including parent directories).
+- If file creation fails after 1000 attempts, the command exits with a non-zero status and an error message.
+
+## Notes for Implementers
+- Use `secrets.choice` for identifier generation to maintain entropy.
+- Use `Path.touch()` to create files and `Path` operations for portability.
+- Update this spec if the identifier length, alphabet, or logging format changes.

--- a/spec/commands/search.md
+++ b/spec/commands/search.md
@@ -1,0 +1,37 @@
+# Command: `oct search`
+
+Search for concept files by identifier or content.
+
+## Purpose
+- Quickly locate concepts using partial identifiers or keywords in `.oct` files.
+- Provide a filesystem-aware search scoped to the terminology tree.
+
+## Behavior
+- Default search root is `terms/<language>/` relative to the repository root.
+- Recursively searches for files ending in `.oct`.
+- Matches are reported when:
+  - The query substring matches the filename (identifier), or
+  - The query substring appears in the file contents (case-insensitive).
+- Outputs matching identifiers or `filename # content` snippets for content matches.
+- If no matches are found, prints `No matches found.`
+
+## Arguments & Options
+- `query` (positional): Text to search for in filenames or file contents.
+- `--directory`, `-d`: Override the search root directory. Defaults to `terms/<language>/`.
+- `--language`, `-l`: Language code used to select the default search directory. Defaults to `en-GB`.
+
+## Usage Examples
+```bash
+./oct search flu
+./oct search ABC123 --language en-US
+./oct search heart --directory /custom/terms
+```
+
+## Validation & Error Handling
+- If the search directory does not exist, the command prints `Directory not found: <path>` and exits without scanning.
+- Files that cannot be read emit a `Could not read <path>` message and the scan continues.
+
+## Notes for Implementers
+- Use `Path.rglob('*.oct')` for recursive discovery to keep behavior consistent across platforms.
+- Keep search case-insensitive for both identifiers and contents.
+- Avoid truncating content in the output for now; adjust this spec if summarization rules are added.


### PR DESCRIPTION
## Summary
- add top-level specification index with coding style guidance for OCT tooling
- document the `oct new` command behavior, options, and validation rules
- document the `oct search` command behavior, options, and error handling

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278db730908326adb454155ac53a07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OCT specification documentation with coding standards and contributor guidelines
  * Added specification for `oct new` command to create unique term files with generated identifiers
  * Added specification for `oct search` command to search across term files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->